### PR TITLE
CharLS: update and support CharLS 2.1 version

### DIFF
--- a/cmakelists/gdal/frmts/jpegls/CMakeLists.txt
+++ b/cmakelists/gdal/frmts/jpegls/CMakeLists.txt
@@ -1,7 +1,11 @@
 add_gdal_driver(TARGET gdal_JPEGLS SOURCES jpegls_header.h jpeglsdataset.cpp)
 gdal_standard_includes(gdal_JPEGLS)
-gdal_target_link_libraries(TARGET gdal_JPEGLS LIBRARIES CHARLS::CHARLS)
+gdal_target_link_libraries(TARGET gdal_JPEGLS LIBRARIES CharLS::CharLS)
 
-if (CHARLS_VERSION STREQUAL 1)
+if (CharLS_VERSION STREQUAL 1)
   target_compile_definitions(gdal_JPEGLS PRIVATE -DCHARLS_INTERFACE_H)
+elseif (CharLS_VERSION STREQUAL 2.1)
+  target_compile_definitions(gdal_JPEGLS PRIVATE -DCHARLS_2_1)
+else ()
+  target_compile_definitions(gdal_JPEGLS PRIVATE -DCHARLS_2)
 endif ()

--- a/modules/packages/FindCharLS.cmake
+++ b/modules/packages/FindCharLS.cmake
@@ -1,54 +1,77 @@
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 
-#.rst:
-# FindCharLS - JPEG Loss-Less Open SOurce Library CharLS
-# --------
-#
-# Find CharLS
-#
-# ::
-#
-#   CHARLS_INCLUDE_DIR, where to find charls.h, etc.
-#   CHARLS_LIBRARIES, the libraries needed to use CharLS.
-#   CHARLS_FOUND, If false, do not try to use CharLS.
-#   CHARLS_VERSION, 1 if CharLS/interface.h exist and 2 if CharLS/charls.h exist
-#
+#[=======================================================================[.rst:
+FindCharLS
+----------
 
-find_path(CHARLS_INCLUDE_DIR NAMES charls.h SUFFIX_PATHS CharLS)
-find_path(CHARLS_INCLUDE_DIR NAMES interface.h SUFFIX_PATHS CharLS)
+FindCharLS - JPEG Loss-Less Open SOurce Library CharLS
 
-if(CHARLS_INCLUDE_DIR)
-    if(EXISTS "${CHARLS_INCLUDE_DIR}/CharLS/interface.h")
-        set(CHARLS_VERSION 1)
+IMPORTED Targets
+^^^^^^^^^^^^^^^^
+
+``CharLS::charls``
+  This module defines :prop_tgt:`IMPORTED` target ``CharLS::charls``, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+   ``CharLS_FOUND``
+     If false, do not try to use CharLS.
+   ``CharLS_INCLUDE_DIRS``
+     where to find charls.h, etc.
+   ``CharLS_LIBRARIES``
+     the libraries needed to use CharLS.
+   ``CharLS_VERSION``
+     1 if CharLS/interface.h exist ,and 2 if CharLS/charls.h exist,
+     and 2.1 if charls/charls.h exist when CharLS 2.1 and later.
+
+#]=======================================================================]
+
+find_path(CharLS_INCLUDE_DIR NAMES charls/charls.h)
+find_path(CharLS_INCLUDE_DIR NAMES CharLS/charls.h)
+find_path(CharLS_INCLUDE_DIR NAMES CharLS/interface.h)
+
+if(CharLS_INCLUDE_DIR)
+    if(EXISTS "${CharLS_INCLUDE_DIR}/charls/charls.h")
+        set(CharLS_VERSION 2.1)
+    elseif(EXISTS "${CharLS_INCLUDE_DIR}/CharLS/interface.h")
+        set(CharLS_VERSION 1)
     else()
-        set(CHARLS_VERSION 2)
+        set(CharLS_VERSION 2)
     endif()
 endif()
 
-find_library(CHARLS_LIBRARY NAMES CharLS)
+find_library(CharLS_LIBRARY NAMES CharLS)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(CharLS
-                                  FOUND_VAR CHARLS_FOUND
-                                  REQUIRED_VARS CHARLS_LIBRARY CHARLS_INCLUDE_DIR
-                                  VERSION_VAR CHARLS_VERSION)
-mark_as_advanced(CHARLS_LIBRARY CHARLS_INCLUDE_DIR CHARLS_VERSION)
+                                  FOUND_VAR CharLS_FOUND
+                                  REQUIRED_VARS CharLS_LIBRARY CharLS_INCLUDE_DIR
+                                  VERSION_VAR CharLS_VERSION)
+mark_as_advanced(CharLS_LIBRARY CharLS_INCLUDE_DIR CharLS_VERSION)
 
 include(FeatureSummary)
-set_package_properties(CHARLS PROPERTIES
-                       DESCRIPTION "C++ JPEG Loss-Less Open SOurce Library Implementation."
+set_package_properties(CharLS PROPERTIES
+                       DESCRIPTION "C++ JPEG Loss-Less Open Source Library Implementation."
                        URL "https://github.com/team-charls/charls"
 )
 
-if(CHARLS_FOUND)
-    set(CHARLS_LIBRARIES ${CHARLS_LIBRARY})
-    set(CHARLS_INCLUDE_DIRS ${CHARLS_INCLUDE_DIR})
-    if(NOT TARGET CHARLS::CHARLS)
-        add_library(CHARLS::CHARLS UNKNOWN IMPORTED)
-        set_target_properties(CHARLS::CHARLS PROPERTIES
-                              INTERFACE_INLUDE_DIRECTORIES ${CHARLS_INCLUDE_DIR}
-                              IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-                              IMPORTED_LOCATION ${CHARLS_LIBRARY})
+if(CharLS_FOUND)
+    set(CharLS_LIBRARIES ${CharLS_LIBRARY})
+    set(CharLS_INCLUDE_DIRS ${CharLS_INCLUDE_DIR})
+    if(NOT TARGET CharLS::charls)
+        add_library(CharLS::charls UNKNOWN IMPORTED)
+        if(CharLS_INCLUDE_DIRS)
+          set_target_properties(CharLS::charls PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES ${CharLS_INCLUDE_DIR})
+        endif()
+        if(EXISTS "${CharLS_LIBRARY}")
+          set_target_property(CharLS::charls PROPERTIES
+            IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
+            IMPORTED_LOCATION ${CharLS_LIBRARY})
+        endif()
    endif()
 endif()


### PR DESCRIPTION
This change intend to adjust help message, result variable name
with standard of upstream cmake. And also support detecting
CharLS 2.1 version change.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>