### PR TITLE
CI: github: change sfcgal version

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
 
-  build-linux-20.04:
+  build-linux-ubuntu-focal:
     runs-on: ubuntu-20.04
     env:
       CONFIGURATION: gdal/cmake4gdal/configurations/full_drivers.cmake


### PR DESCRIPTION
sfcgal 1.3.7 in ubuntu 20.04 has a bug producing link error.
This patch intendo to use a PPA for sfcgal 1.3.9 that has a fix the error.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>