### PR TITLE
FindPoppler: capture minor version without leading zero

### DIFF
--- a/modules/packages/FindPoppler.cmake
+++ b/modules/packages/FindPoppler.cmake
@@ -99,7 +99,7 @@ if(NOT POPPLER_VERSION_STRING)
            "${_poppler_version_header_contents}"
            )
     string(REGEX REPLACE
-           "^.*[ \t]+POPPLER_VERSION_MINOR[ \t]+0?([0-9]+).*$"
+           "^.*[ \t]+POPPLER_VERSION_MINOR[ \t]+([0-9]+).*$"
            "\\1"
            POPPLER_VERSION_MINOR
            "${_poppler_version_header_contents}"

--- a/modules/packages/FindPoppler.cmake
+++ b/modules/packages/FindPoppler.cmake
@@ -43,9 +43,6 @@ This module defines the following variables:
 find_package(PkgConfig QUIET)
 if(PKG_CONFIG_FOUND)
   pkg_check_modules(PC_Poppler QUIET poppler)
-  if(PC_Poppler_VERSION)
-    set(POPPLER_VERSION_STRING ${PC_Poppler_VERSION})
-  endif()
 endif()
 find_path(POPPLER_INCLUDE_DIR NAMES "poppler-config.h" "cpp/poppler-version.h" "qt5/poppler-qt5.h" "qt4/poppler-qt4.h"
           "glib/poppler.h"

--- a/modules/packages/FindPoppler.cmake
+++ b/modules/packages/FindPoppler.cmake
@@ -102,7 +102,7 @@ if(NOT POPPLER_VERSION_STRING)
            "${_poppler_version_header_contents}"
            )
     string(REGEX REPLACE
-           "^.*[ \t]+POPPLER_VERSION_MINOR[ \t]+([0-9]+).*$"
+           "^.*[ \t]+POPPLER_VERSION_MINOR[ \t]+0?([0-9]+).*$"
            "\\1"
            POPPLER_VERSION_MINOR
            "${_poppler_version_header_contents}"


### PR DESCRIPTION
leading zero treated as octal number in C code but
it can be 08 and 09. This cuase compilation error.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>